### PR TITLE
Make __all__ a tuple

### DIFF
--- a/api_utils/app.py
+++ b/api_utils/app.py
@@ -11,7 +11,7 @@ from flask import Flask, request
 
 from . import formatters
 
-__all__ = ('ResponsiveFlask')
+__all__ = ('ResponsiveFlask',)
 
 
 class ResponsiveFlask(Flask):

--- a/api_utils/auth.py
+++ b/api_utils/auth.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     pass
 
-__all__ = ('Hawk')
+__all__ = ('Hawk',)
 
 
 class Hawk(object):


### PR DESCRIPTION
Remember, it's the comma that makes a tuple a tuple, not the parens.

Also, the parens are not required, so you could just write:

``` py
__all__ == "ResponsiveFlask",
```
